### PR TITLE
Fix Pokémon role identification and refactor service logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ yarn-debug.log*
 .yarn-integrity
 
 /coverage
+
+/.vscode

--- a/lib/services/pokemon_service.rb
+++ b/lib/services/pokemon_service.rb
@@ -1,21 +1,34 @@
 # frozen_string_literal: true
 
+require_relative '../types/pokemon_role' # Adds the dependency
+
 module Services
-  # PokemonService faz a requisicao de dados do servico Pokemon
+  # PokemonService encapsulates Pokemon-related logic
   class PokemonService
+    def initialize(repository: Repositories::PokemonRepository.new)
+      @repository = repository
+    end
+
     def self.get_all
-      Repositories::PokemonRepository.new.get_all
+      new.get_all
+    end
+
+    def get_all
+      @repository.get_all
     end
 
     def find_counter(id)
-      pokemon = Repositories::PokemonRepository.new.find_by_id(id)
-      pokemon_role = identify_role(pokemon.id)
+      pokemon = @repository.find_by_id(id)
+      # Uses the new module to identify the role
+      pokemon_role = Types::PokemonRole.identify(pokemon)
 
-      # Verifica se o Pokémon tem tipo secundário
       type_b_name = pokemon.type_b&.name
       types = type_counters(pokemon.type_a.name, type_b_name)
 
-      counters = role_selector(pokemon_role, types)
+      # Uses the new module to get the sorting attributes
+      sort_attributes = Types::PokemonRole::SORT_ATTRIBUTES[pokemon_role]
+      counters = counter_sort(*types, *sort_attributes)
+
       counters.reject! { |counter| counter[:total] < pokemon.total }
     end
 
@@ -27,44 +40,25 @@ module Services
     def find_team_counters(team_names)
       raise 'Um time completo precisa ter 6 Pokémon' if team_names.length != 6
 
-      team = []
-      team_names.each do |name|
-        pokemon = Repositories::PokemonRepository.new.find_by_name(name)
+      team = team_names.map do |name|
+        pokemon = @repository.find_by_name(name)
         raise "Pokémon não encontrado: #{name}" if pokemon.nil?
-        team << pokemon
+
+        pokemon
       end
 
-      # Simplificando a lógica para garantir que sempre retornamos 6 Pokémon
-      # Pegar os primeiros 20 Pokémon com maior total que não estão no time original
       all_counters = Pokemon.where.not(id: team.map(&:id))
                             .order(total: :desc)
                             .limit(20)
                             .to_a
-      
-      # Se não encontramos counters suficientes, incluir qualquer Pokémon que não está no time
+
       if all_counters.length < 6
         additional_counters = Pokemon.where.not(id: team.map(&:id) + all_counters.map(&:id))
-                                    .limit(6 - all_counters.length)
+                                     .limit(6 - all_counters.length)
         all_counters.concat(additional_counters)
       end
-      
-      # Garantir que retornamos exatamente 6 Pokémon (ou todos disponíveis se forem menos de 6)
-      all_counters.take(6)
-    end
 
-    def role_selector(pokemon_role, types)
-      case pokemon_role
-      when 'Physical Sweeper'
-        counter_sort(*types, :defense, :hp, :special_defense)
-      when 'Special Sweeper'
-        counter_sort(*types, :special_defense, :hp, :defense)
-      when 'Physical Tank'
-        counter_sort(*types, :attack, :speed, :hp)
-      when 'Special Tank'
-        counter_sort(*types, :special_attack, :speed, :hp)
-      else
-        counter_sort(*types, :attack, :special_attack, :speed)
-      end
+      all_counters.take(6)
     end
 
     def type_counters(type_a, type_b)
@@ -75,31 +69,20 @@ module Services
       end
     end
 
-    def identify_role(id)
-      pokemon = Repositories::PokemonRepository.new.find_by_id(id)
-      stats = [pokemon.hp, pokemon.attack, pokemon.special_attack, pokemon.defense, pokemon.special_defense,
-               pokemon.speed].max(2)
-
-      if stats.include?(pokemon.attack) && stats.include?(pokemon.speed)
-        'Physical Sweeper'
-      elsif stats.include?(pokemon.special_attack) && stats.include?(pokemon.speed)
-        'Special Sweeper'
-      elsif stats.include?(pokemon.attack) && stats.include?(pokemon.defense)
-        'Physical Tank'
-      elsif stats.include?(pokemon.special_attack) && stats.include?(pokemon.defense)
-        'Special Tank'
-      else
-        'General'
-      end
-    end
-
     def counter_sort(*types, sort_a, sort_b, sort_c)
       counters = []
       types.each do |type|
-        counters << type.pokemon_a.order(sort_a, sort_b, sort_c)
-        counters << type.pokemon_b.order(sort_a, sort_b, sort_c) unless type.pokemon_b.nil?
+        # Ensures that the query is done correctly
+        # Assuming that type.pokemon_a and type.pokemon_b return Active Record Relations
+        counters << type.pokemon_a.order(sort_a => :desc, sort_b => :desc, sort_c => :desc)
+        # Checks if pokemon_b exists before trying to access it
+        counters << Array.wrap(type.pokemon_b&.order(sort_a => :desc, sort_b => :desc, sort_c => :desc))
       end
-      counters.flatten!
+      # Uses flat_map to simplify and ensures they are arrays before concatenating
+      counters = counters.flat_map(&:to_a)
+      # Removes duplicates based on Pokemon ID
+      counters.uniq!(&:id)
+      # Sorts by total in descending order as before
       counters.sort_by(&:total).reverse
     end
   end

--- a/lib/types/pokemon_role.rb
+++ b/lib/types/pokemon_role.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Types
+  # Define os possíveis papéis (roles) de um Pokémon em batalha.
+  module PokemonRole
+    PHYSICAL_SWEEPER = :physical_sweeper
+    SPECIAL_SWEEPER = :special_sweeper
+    PHYSICAL_TANK = :physical_tank
+    SPECIAL_TANK = :special_tank
+    GENERAL = :general
+
+    ALL = [
+      PHYSICAL_SWEEPER,
+      SPECIAL_SWEEPER,
+      PHYSICAL_TANK,
+      SPECIAL_TANK,
+      GENERAL
+    ].freeze
+
+    # Mapeamento de roles para os atributos de ordenação prioritários
+    SORT_ATTRIBUTES = {
+      PHYSICAL_SWEEPER => [:defense, :hp, :special_defense],
+      SPECIAL_SWEEPER => [:special_defense, :hp, :defense],
+      PHYSICAL_TANK => [:attack, :speed, :hp],
+      SPECIAL_TANK => [:special_attack, :speed, :hp],
+      GENERAL => [:attack, :special_attack, :speed]
+    }.freeze
+
+    def self.identify(pokemon)
+      # Define um threshold para determinar se as estatísticas são balanceadas
+      threshold = 10
+      
+      # Calcula a média das estatísticas principais
+      stats = [pokemon.hp, pokemon.attack, pokemon.special_attack, pokemon.defense, pokemon.special_defense, pokemon.speed]
+      avg_stats = stats.sum.to_f / stats.size
+      
+      # Verifica se as estatísticas estão dentro do threshold da média (estatísticas balanceadas)
+      balanced = stats.all? { |stat| (stat - avg_stats).abs <= threshold }
+      
+      # Se as estatísticas forem balanceadas, retorna GENERAL
+      return GENERAL if balanced
+      
+      # Caso contrário, identifica a role baseada nas duas maiores estatísticas
+      top_two = stats.max(2)
+
+      if top_two.include?(pokemon.attack) && top_two.include?(pokemon.speed)
+        PHYSICAL_SWEEPER
+      elsif top_two.include?(pokemon.special_attack) && top_two.include?(pokemon.speed)
+        SPECIAL_SWEEPER
+      elsif top_two.include?(pokemon.attack) && top_two.include?(pokemon.defense)
+        PHYSICAL_TANK
+      elsif top_two.include?(pokemon.special_attack) && top_two.include?(pokemon.special_defense)
+        SPECIAL_TANK
+      else
+        GENERAL
+      end
+    end
+  end
+end

--- a/lib/types/pokemon_role.rb
+++ b/lib/types/pokemon_role.rb
@@ -19,27 +19,28 @@ module Types
 
     # Mapeamento de roles para os atributos de ordenação prioritários
     SORT_ATTRIBUTES = {
-      PHYSICAL_SWEEPER => [:defense, :hp, :special_defense],
-      SPECIAL_SWEEPER => [:special_defense, :hp, :defense],
-      PHYSICAL_TANK => [:attack, :speed, :hp],
-      SPECIAL_TANK => [:special_attack, :speed, :hp],
-      GENERAL => [:attack, :special_attack, :speed]
+      PHYSICAL_SWEEPER => %i[defense hp special_defense],
+      SPECIAL_SWEEPER => %i[special_defense hp defense],
+      PHYSICAL_TANK => %i[attack speed hp],
+      SPECIAL_TANK => %i[special_attack speed hp],
+      GENERAL => %i[attack special_attack speed]
     }.freeze
 
     def self.identify(pokemon)
       # Define um threshold para determinar se as estatísticas são balanceadas
       threshold = 10
-      
+
       # Calcula a média das estatísticas principais
-      stats = [pokemon.hp, pokemon.attack, pokemon.special_attack, pokemon.defense, pokemon.special_defense, pokemon.speed]
+      stats = [pokemon.hp, pokemon.attack, pokemon.special_attack, pokemon.defense, pokemon.special_defense,
+               pokemon.speed]
       avg_stats = stats.sum.to_f / stats.size
-      
+
       # Verifica se as estatísticas estão dentro do threshold da média (estatísticas balanceadas)
       balanced = stats.all? { |stat| (stat - avg_stats).abs <= threshold }
-      
+
       # Se as estatísticas forem balanceadas, retorna GENERAL
       return GENERAL if balanced
-      
+
       # Caso contrário, identifica a role baseada nas duas maiores estatísticas
       top_two = stats.max(2)
 

--- a/spec/types/pokemon_role_spec.rb
+++ b/spec/types/pokemon_role_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'types/pokemon_role' # Ensure the module is loaded
+
+RSpec.describe Types::PokemonRole do
+  # Describes the behavior of the .identify method
+  describe '.identify' do
+    # Creates a Pokémon mock for testing
+    # Use `build_stubbed` or `create` from FactoryBot if factories are configured
+    # Or a simple OpenStruct/double as shown below:
+    let(:pokemon_mock) { instance_double(Pokemon) }
+
+    context 'when the Pokémon is a Physical Sweeper' do
+      it 'returns :physical_sweeper' do
+        # Configures the mock to simulate a Physical Sweeper (high Attack and Speed)
+        allow(pokemon_mock).to receive_messages(
+          hp: 100, attack: 150, special_attack: 80,
+          defense: 90, special_defense: 85, speed: 140
+        )
+        expect(described_class.identify(pokemon_mock)).to eq(Types::PokemonRole::PHYSICAL_SWEEPER)
+      end
+    end
+
+    context 'when the Pokémon is a Special Sweeper' do
+      it 'returns :special_sweeper' do
+        # Configures the mock to simulate a Special Sweeper (high Special Attack and Speed)
+        allow(pokemon_mock).to receive_messages(
+          hp: 100, attack: 80, special_attack: 150,
+          defense: 90, special_defense: 85, speed: 140
+        )
+        expect(described_class.identify(pokemon_mock)).to eq(Types::PokemonRole::SPECIAL_SWEEPER)
+      end
+    end
+
+    context 'when the Pokémon is a Physical Tank' do
+      it 'returns :physical_tank' do
+        # Configures the mock to simulate a Physical Tank (high Attack and Defense)
+        allow(pokemon_mock).to receive_messages(
+          hp: 120, attack: 140, special_attack: 70,
+          defense: 130, special_defense: 80, speed: 60
+        )
+        expect(described_class.identify(pokemon_mock)).to eq(Types::PokemonRole::PHYSICAL_TANK)
+      end
+    end
+
+    context 'when the Pokémon is a Special Tank' do
+      it 'returns :special_tank' do
+        # Configures the mock to simulate a Special Tank (high Special Attack and Special Defense)
+        allow(pokemon_mock).to receive_messages(
+          hp: 120, attack: 70, special_attack: 140,
+          defense: 80, special_defense: 130, speed: 60 # Adjusted: high special_defense
+        )
+        expect(described_class.identify(pokemon_mock)).to eq(Types::PokemonRole::SPECIAL_TANK)
+      end
+    end
+
+    context 'when the Pokémon does not fit specific roles' do
+      it 'returns :general' do
+        # Configures the mock with more balanced stats, avoiding specific triggers
+        allow(pokemon_mock).to receive_messages(
+          hp: 100, attack: 100, special_attack: 105, # special_attack ligeiramente maior
+          defense: 100, special_defense: 100, speed: 95 # speed ligeiramente menor
+        )
+        expect(described_class.identify(pokemon_mock)).to eq(Types::PokemonRole::GENERAL)
+      end
+    end
+  end
+
+  # Add tests for SORT_ATTRIBUTES if necessary
+  describe '::SORT_ATTRIBUTES' do
+    it 'mapeia roles para os atributos corretos' do
+      expect(described_class::SORT_ATTRIBUTES[Types::PokemonRole::PHYSICAL_SWEEPER]).to eq(%i[defense hp
+                                                                                              special_defense])
+      expect(described_class::SORT_ATTRIBUTES[Types::PokemonRole::SPECIAL_SWEEPER]).to eq(%i[special_defense hp
+                                                                                             defense])
+      expect(described_class::SORT_ATTRIBUTES[Types::PokemonRole::PHYSICAL_TANK]).to eq(%i[attack speed hp])
+      expect(described_class::SORT_ATTRIBUTES[Types::PokemonRole::SPECIAL_TANK]).to eq(%i[special_attack speed hp])
+      expect(described_class::SORT_ATTRIBUTES[Types::PokemonRole::GENERAL]).to eq(%i[attack special_attack speed])
+    end
+  end
+end


### PR DESCRIPTION
Correct the identification of Pokémon with balanced stats as 'General' and introduce a new logic for determining Pokémon roles. Refactor the `PokemonService` to improve code organization and efficiency. This update enhances the overall functionality and maintainability of the Pokémon identification system.